### PR TITLE
提高测试覆盖率（部分）

### DIFF
--- a/MaaCopilotServer.sln
+++ b/MaaCopilotServer.sln
@@ -26,11 +26,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD2BFB2C-6E2E-42AE-B55F-9C225D5EBE23}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		README.md = README.md
-		LICENSE = LICENSE
-		Dockerfile = Dockerfile
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		Dockerfile = Dockerfile
+		LICENSE = LICENSE
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Github Actions", "Github Actions", "{5F4AA980-88F9-4FB8-9AB0-8CC2740BF139}"
@@ -41,10 +41,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Github Actions", "Github Ac
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{E3AD1038-CD00-4615-9AEE-5F89A882C448}"
 	ProjectSection(SolutionItems) = preProject
-		push-docker.sh = push-docker.sh
 		build-docker.sh = build-docker.sh
 		publish-api.ps1 = publish-api.ps1
 		publish-api.sh = publish-api.sh
+		push-docker.sh = push-docker.sh
 	EndProjectSection
 EndProject
 Global

--- a/src/MaaCopilotServer.Api/ConfigureServices.cs
+++ b/src/MaaCopilotServer.Api/ConfigureServices.cs
@@ -19,7 +19,6 @@ namespace MaaCopilotServer.Api;
 /// <summary>
 ///     The extension to add API service to the services.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public static class ConfigureServices
 {
     /// <summary>

--- a/src/MaaCopilotServer.Api/Helper/ConfigurationHelper.cs
+++ b/src/MaaCopilotServer.Api/Helper/ConfigurationHelper.cs
@@ -11,7 +11,6 @@ namespace MaaCopilotServer.Api.Helper;
 /// <summary>
 ///     The helper class of the configurations of the application.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public static class ConfigurationHelper
 {
     /// <summary>

--- a/src/MaaCopilotServer.Api/Helper/InitializeHelper.cs
+++ b/src/MaaCopilotServer.Api/Helper/InitializeHelper.cs
@@ -24,7 +24,6 @@ public static class InitializeHelper
     /// <summary>
     /// Initializes email templates.
     /// </summary>
-    [ExcludeFromCodeCoverage]
     public static void InitializeEmailTemplates()
     {
         var originalTemplatesDirectory = new DirectoryInfo(GlobalConstants.OriginalTemplatesDirectory);
@@ -51,7 +50,6 @@ public static class InitializeHelper
     /// Initializes the database.
     /// </summary>
     /// <param name="configuration">The configuration.</param>
-    [ExcludeFromCodeCoverage]
     public static void InitializeDatabase(IConfiguration configuration)
     {
         // Establish database connection.

--- a/src/MaaCopilotServer.Api/Helper/LoggerConfigurationHelper.cs
+++ b/src/MaaCopilotServer.Api/Helper/LoggerConfigurationHelper.cs
@@ -16,7 +16,6 @@ namespace MaaCopilotServer.Api.Helper;
 /// <summary>
 ///     The helper class of logger.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public static class LoggerConfigurationHelper
 {
     /// <summary>

--- a/src/MaaCopilotServer.Api/Services/CurrentUserService.cs
+++ b/src/MaaCopilotServer.Api/Services/CurrentUserService.cs
@@ -29,7 +29,6 @@ public class CurrentUserService : ICurrentUserService
     /// </summary>
     /// <param name="httpContextAccessor">The HTTP context accessor.</param>
     /// <param name="configuration">The configuration.</param>
-    [ExcludeFromCodeCoverage]
     public CurrentUserService(
         IHttpContextAccessor httpContextAccessor,
         IConfiguration configuration)

--- a/src/MaaCopilotServer.Application/Common/Extensions/DirectoryInfoExtension.cs
+++ b/src/MaaCopilotServer.Application/Common/Extensions/DirectoryInfoExtension.cs
@@ -10,7 +10,6 @@ namespace MaaCopilotServer.Application.Common.Extensions;
 /// <summary>
 ///     The extension of <see cref="DirectoryInfo" />.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public static class DirectoryInfoExtension
 {
     /// <summary>

--- a/src/MaaCopilotServer.Application/Common/Extensions/FileInfoExtension.cs
+++ b/src/MaaCopilotServer.Application/Common/Extensions/FileInfoExtension.cs
@@ -10,7 +10,6 @@ namespace MaaCopilotServer.Application.Common.Extensions;
 /// <summary>
 ///     The extension of <see cref="FileInfo" />.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public static class FileInfoExtension
 {
     /// <summary>

--- a/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommand.cs
+++ b/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommand.cs
@@ -108,72 +108,9 @@ public class CreateCopilotOperationCommandHandler : IRequestHandler<CreateCopilo
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         var id = _copilotIdService.EncodeId(entity.Id);
-        return MaaApiResponseHelper.Ok(new CreateCopilotOperationDto(id));
+        return MaaApiResponseHelper.Ok(new CreateCopilotOperationDto()
+        {
+            Id = id,
+        });
     }
-}
-
-/// <summary>
-/// The JSON request content of creating copilot operation.
-/// </summary>
-internal record CreateCopilotOperationContent
-{
-    /// <summary>
-    /// The <c>stage_name</c> field.
-    /// </summary>
-    [JsonPropertyName("stage_name")]
-    public string? StageName { get; set; }
-
-    /// <summary>
-    /// The <c>minimum_required</c> field.
-    /// </summary>
-    [JsonPropertyName("minimum_required")]
-    public string? MinimumRequired { get; set; }
-
-    /// <summary>
-    /// The <c>doc</c> field.
-    /// </summary>
-    [JsonPropertyName("doc")]
-    public Doc? Doc { get; set; }
-
-    /// <summary>
-    /// The <c>opers</c> field.
-    /// </summary>
-    [JsonPropertyName("opers")]
-    public Operator[]? Operators { get; set; }
-}
-
-/// <summary>
-/// The JSON content of <c>doc</c>.
-/// </summary>
-internal record Doc
-{
-    /// <summary>
-    /// The <c>title</c> field.
-    /// </summary>
-    [JsonPropertyName("title")]
-    public string? Title { get; set; }
-
-    /// <summary>
-    /// The <c>details</c> field.
-    /// </summary>
-    [JsonPropertyName("details")]
-    public string? Details { get; set; }
-}
-
-/// <summary>
-/// The JSON content of <c>operator</c>.
-/// </summary>
-internal record Operator
-{
-    /// <summary>
-    /// The <c>name</c> field.
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
-
-    /// <summary>
-    /// The <c>skill</c> field.
-    /// </summary>
-    [JsonPropertyName("skill")]
-    public int? Skill { get; set; }
 }

--- a/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationContent.cs
+++ b/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationContent.cs
@@ -1,0 +1,74 @@
+// This file is a part of MaaCopilotServer project.
+// MaaCopilotServer belongs to the MAA organization.
+// Licensed under the AGPL-3.0 license.
+
+using System.Text.Json.Serialization;
+
+namespace MaaCopilotServer.Application.CopilotOperation.Commands.CreateCopilotOperation;
+
+/// <summary>
+/// The JSON request content of creating copilot operation.
+/// </summary>
+public record CreateCopilotOperationContent
+{
+    /// <summary>
+    /// The <c>stage_name</c> field.
+    /// </summary>
+    [JsonPropertyName("stage_name")]
+    public string? StageName { get; set; }
+
+    /// <summary>
+    /// The <c>minimum_required</c> field.
+    /// </summary>
+    [JsonPropertyName("minimum_required")]
+    public string? MinimumRequired { get; set; }
+
+    /// <summary>
+    /// The <c>doc</c> field.
+    /// </summary>
+    [JsonPropertyName("doc")]
+    public Doc? Doc { get; set; }
+
+    /// <summary>
+    /// The <c>opers</c> field.
+    /// </summary>
+    [JsonPropertyName("opers")]
+    public Operator[]? Operators { get; set; }
+}
+
+
+/// <summary>
+/// The JSON content of <c>doc</c>.
+/// </summary>
+public record Doc
+{
+    /// <summary>
+    /// The <c>title</c> field.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// The <c>details</c> field.
+    /// </summary>
+    [JsonPropertyName("details")]
+    public string? Details { get; set; }
+}
+
+/// <summary>
+/// The JSON content of <c>operator</c>.
+/// </summary>
+public record Operator
+{
+    /// <summary>
+    /// The <c>name</c> field.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The <c>skill</c> field.
+    /// </summary>
+    [JsonPropertyName("skill")]
+    public int? Skill { get; set; }
+}

--- a/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationDto.cs
+++ b/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationDto.cs
@@ -9,24 +9,11 @@ namespace MaaCopilotServer.Application.CopilotOperation.Commands.CreateCopilotOp
 /// <summary>
 ///     The DTO of creating operation.
 /// </summary>
-public class CreateCopilotOperationDto
+public record CreateCopilotOperationDto
 {
-    /// <summary>
-    ///     The constructor of <see cref="CreateCopilotOperationDto" />.
-    /// </summary>
-    /// <param name="id">The operation ID.</param>
-    public CreateCopilotOperationDto(string id)
-    {
-        Id = id;
-    }
-
-#pragma warning disable CS8618
-    public CreateCopilotOperationDto() { }
-#pragma warning restore CS8618
-
     /// <summary>
     ///     The operation ID.
     /// </summary>
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = string.Empty;
 }

--- a/src/MaaCopilotServer.Domain/Entities/CopilotOperation.cs
+++ b/src/MaaCopilotServer.Domain/Entities/CopilotOperation.cs
@@ -52,67 +52,64 @@ public sealed class CopilotOperation : EditableEntity
         UpdateBy = createBy;
     }
 
-#pragma warning disable CS8618
-    // ReSharper disable once UnusedMember.Local
-    private CopilotOperation() { }
-#pragma warning restore CS8618
+    public CopilotOperation() { }
 
     /// <summary>
     ///     作业 ID (数字ID)
     /// </summary>
-    public long Id { get; private set; }
+    public long Id { get; set; }
 
     /// <summary>
     ///     作业组 ID
     /// </summary>
-    public Guid GroupId { get; private set; }
+    public Guid GroupId { get; set; } = Guid.Empty;
 
     /// <summary>
     ///     作业本体 JSON
     /// </summary>
-    public string Content { get; private set; }
+    public string Content { get; set; } = string.Empty;
 
     /// <summary>
     ///     下载量
     /// </summary>
-    public int Downloads { get; private set; }
+    public int Downloads { get; set; }
 
     /// <summary>
     ///     收藏量
     /// </summary>
-    public int Favorites { get; private set; }
+    public int Favorites { get; set; }
 
     // Extract from Content
 
     /// <summary>
     ///     关卡名称
     /// </summary>
-    public string StageName { get; private set; }
+    public string StageName { get; set; } = string.Empty;
 
     /// <summary>
     ///     MAA 所需最低版本
     /// </summary>
-    public string MinimumRequired { get; private set; }
+    public string MinimumRequired { get; set; } = string.Empty;
 
     /// <summary>
     ///     标题
     /// </summary>
-    public string Title { get; private set; }
+    public string Title { get; set; } = string.Empty;
 
     /// <summary>
     ///     干员列表
     /// </summary>
-    public List<string> Operators { get; private set; }
+    public List<string> Operators { get; set; } = new List<string>();
 
     /// <summary>
     ///     简介
     /// </summary>
-    public string Details { get; private set; }
+    public string Details { get; set; } = string.Empty;
 
     /// <summary>
     ///     上传者
     /// </summary>
-    public CopilotUser Author { get; private set; }
+    public CopilotUser Author { get; set; } = new CopilotUser();
 
     /// <summary>
     ///     Increases download count by 1, and updates last updated time.

--- a/src/MaaCopilotServer.Domain/Entities/CopilotUser.cs
+++ b/src/MaaCopilotServer.Domain/Entities/CopilotUser.cs
@@ -42,34 +42,34 @@ public class CopilotUser : EditableEntity
     /// <summary>
     ///     The default constructor.
     /// </summary>
-    // ReSharper disable once UnusedMember.Local
-    public CopilotUser() : this(default!, default!, default!, UserRole.User, null)
-    { }
+    public CopilotUser()
+    {
+    }
 
     /// <summary>
     ///     邮箱
     /// </summary>
-    public string Email { get; private set; }
+    public string Email { get; set; } = string.Empty;
 
     /// <summary>
     ///     密码
     /// </summary>
-    public string Password { get; private set; }
+    public string Password { get; set; } = string.Empty;
 
     /// <summary>
     ///     用户名
     /// </summary>
-    public string UserName { get; private set; }
+    public string UserName { get; set; } = string.Empty;
 
     /// <summary>
     ///     权限组
     /// </summary>
-    public UserRole UserRole { get; private set; }
+    public UserRole UserRole { get; set; } = UserRole.User;
 
     /// <summary>
     ///     用户激活
     /// </summary>
-    public bool UserActivated { get; private set; }
+    public bool UserActivated { get; set; } = true;
 
     /// <summary>
     ///     收藏夹

--- a/src/MaaCopilotServer.Infrastructure/Database/MaaCopilotDbContext.cs
+++ b/src/MaaCopilotServer.Infrastructure/Database/MaaCopilotDbContext.cs
@@ -33,6 +33,11 @@ public class MaaCopilotDbContext : DbContext, IMaaCopilotDbContext
         _connectionString = dbOptions.Value.ConnectionString;
     }
 
+    public MaaCopilotDbContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
     /// <summary>
     ///     The DB set of operations.
     /// </summary>
@@ -50,8 +55,10 @@ public class MaaCopilotDbContext : DbContext, IMaaCopilotDbContext
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        var conn = _connectionString.IsNotNull();
-        optionsBuilder.UseNpgsql(conn);
+        if (_connectionString != null)
+        {
+            optionsBuilder.UseNpgsql(_connectionString);
+        }
         base.OnConfiguring(optionsBuilder);
     }
 

--- a/src/MaaCopilotServer.Infrastructure/Database/MaaCopilotDbContext.cs
+++ b/src/MaaCopilotServer.Infrastructure/Database/MaaCopilotDbContext.cs
@@ -25,17 +25,44 @@ public class MaaCopilotDbContext : DbContext, IMaaCopilotDbContext
     private readonly string? _connectionString;
 
     /// <summary>
-    ///     The constructor of <see cref="MaaCopilotDbContext" />.
+    ///     <para>Whether the database is created for unit test or not.</para>
+    ///     <para>When in test mode, an in-memory SQLite database is created.</para>
+    ///     <para>
+    ///         Otherwise, the default PostGreSQL database is created
+    ///         with <see cref="_connectionString"/>.
+    ///     </para>
     /// </summary>
-    /// <param name="dbOptions">The DB options.</param>
+    private readonly bool _isTestMode = false;
+
+    /// <summary>
+    ///     The constructor with <see cref="IOptions{TOptions}"/>.
+    /// </summary>
+    /// <param name="dbOptions">The database options.</param>
     public MaaCopilotDbContext(IOptions<DatabaseOption> dbOptions)
     {
         _connectionString = dbOptions.Value.ConnectionString;
     }
 
+    /// <summary>
+    ///     The constructor with <see cref="DbContextOptions"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <remarks>
+    ///     <para>
+    ///         This constructor is to be used only with unit tests.
+    ///         It is supposed to create an temporary in-memory database
+    ///         only for testing, and will be disposed after the test exits.
+    ///     </para>
+    ///     <para>
+    ///         For development and production, please use
+    ///         <see cref="MaaCopilotDbContext(IOptions{DatabaseOption})"/>
+    ///         instead.
+    ///     </para>
+    /// </remarks>
     public MaaCopilotDbContext(DbContextOptions options)
         : base(options)
     {
+        _isTestMode = true;
     }
 
     /// <summary>
@@ -53,12 +80,18 @@ public class MaaCopilotDbContext : DbContext, IMaaCopilotDbContext
 
     public DbSet<CopilotToken> CopilotTokens { get; set; } = null!;
 
+    /// <inheritdoc/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        if (_connectionString != null)
+        // Create in-memory database when in test mode.
+        if (_isTestMode)
         {
-            optionsBuilder.UseNpgsql(_connectionString);
+            base.OnConfiguring(optionsBuilder);
+            return;
         }
+
+        // Create PostgreSQL database for development and production.
+        optionsBuilder.UseNpgsql(_connectionString.IsNotNull());
         base.OnConfiguring(optionsBuilder);
     }
 

--- a/test/MaaCopilotServer.Application.Test/Common/Behaviours/PerformanceBehaviourTest.cs
+++ b/test/MaaCopilotServer.Application.Test/Common/Behaviours/PerformanceBehaviourTest.cs
@@ -7,6 +7,7 @@ using MaaCopilotServer.Application.Common.Helpers;
 using MaaCopilotServer.Application.Common.Interfaces;
 using MaaCopilotServer.Application.Common.Models;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace MaaCopilotServer.Application.Test.Common.Behaviours;
@@ -34,25 +35,64 @@ public class PerformanceBehaviourTest
     public void Initialize()
     {
         _currentUserService = Substitute.For<ICurrentUserService>();
-        _logger = Substitute.For<ILogger<IRequest<MaaApiResponse>>>();
+        _logger = new TestLogger();
     }
 
     /// <summary>
     ///     Tests
     ///     <see
-    ///         cref="PerformanceBehaviour{TRequest, TResponse}.Handle(TRequest, CancellationToken, MediatR.RequestHandlerDelegate{TResponse})" />
+    ///         cref="PerformanceBehaviour{TRequest, TResponse}.Handle(TRequest, CancellationToken, RequestHandlerDelegate{TResponse})" />
     ///     .
     /// </summary>
     /// <returns>N/A</returns>
-    [TestMethod]
-    public async Task TestHandle()
+    [DataTestMethod]
+    [DataRow(StatusCodes.Status200OK, LogLevel.Information)]
+    [DataRow(StatusCodes.Status400BadRequest, LogLevel.Warning)]
+    [DataRow(StatusCodes.Status401Unauthorized, LogLevel.Warning)]
+    [DataRow(StatusCodes.Status403Forbidden, LogLevel.Warning)]
+    [DataRow(StatusCodes.Status404NotFound, LogLevel.Warning)]
+    [DataRow(StatusCodes.Status500InternalServerError, LogLevel.Error)]
+    public async Task TestHandle(int statusCode, LogLevel expectedLogLevel)
     {
         var testUserId = new Guid();
         _currentUserService.GetUserIdentity().Returns(testUserId);
         var behaviour =
             new PerformanceBehaviour<IRequest<MaaApiResponse>, MaaApiResponse>(_logger, _currentUserService);
-        var action = async () =>
-            await behaviour.Handle(null, new CancellationToken(), () => Task.FromResult(MaaApiResponseHelper.Ok()));
-        await action.Should().NotThrowAsync();
+        await behaviour.Handle(null, new CancellationToken(), () => Task.FromResult(new MaaApiResponse()
+        {
+            StatusCode = statusCode,
+        }));
+        var testLogger = (TestLogger)_logger;
+        testLogger.Called.Should()
+                         .HaveCount(1)
+                         .And
+                         .Contain(expectedLogLevel);
+    }
+
+    /// <summary>
+    /// The test class for logger.
+    /// </summary>
+    private class TestLogger : ILogger<IRequest<MaaApiResponse>>
+    {
+        /// <summary>
+        /// Called arguments of log level.
+        /// </summary>
+        public readonly List<LogLevel> Called = new();
+
+        /// <inheritdoc/>
+        public IDisposable BeginScope<TState>(TState state) => default;
+
+        /// <inheritdoc/>
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        /// <inheritdoc/>
+        public void Log<TState>(LogLevel logLevel,
+                                EventId eventId,
+                                TState state,
+                                Exception? exception,
+                                Func<TState, Exception?, string> formatter)
+        {
+            Called.Add(logLevel);
+        }
     }
 }

--- a/test/MaaCopilotServer.Application.Test/Common/Extensions/DateTimeOffsetExtensionTest.cs
+++ b/test/MaaCopilotServer.Application.Test/Common/Extensions/DateTimeOffsetExtensionTest.cs
@@ -1,0 +1,38 @@
+// This file is a part of MaaCopilotServer project.
+// MaaCopilotServer belongs to the MAA organization.
+// Licensed under the AGPL-3.0 license.
+
+using MaaCopilotServer.Application.Common.Extensions;
+
+namespace MaaCopilotServer.Application.Test.Common.Extensions;
+
+/// <summary>
+/// Tests for <see cref="DateTimeOffsetExtension"/>.
+/// </summary>
+[TestClass]
+public class DateTimeOffsetExtensionTest
+{
+    /// <summary>
+    /// Tests <see cref="DateTimeOffsetExtension.ToUtc8String(DateTimeOffset)"/>.
+    /// </summary>
+    [TestMethod]
+    public void TestToUtc8String()
+    {
+        new DateTimeOffset(2022, 1, 1, 0, 0, 0, new TimeSpan(0))
+            .ToUtc8String()
+            .Should()
+            .Be("2022-01-01 08:00:00 (UTC+8)");
+    }
+
+    /// <summary>
+    /// Tests <see cref="DateTimeOffsetExtension.ToIsoString(DateTimeOffset)"/>.
+    /// </summary>
+    [TestMethod]
+    public void TestToIsoString()
+    {
+        new DateTimeOffset(2022, 1, 1, 0, 0, 0, new TimeSpan(0))
+            .ToIsoString()
+            .Should()
+            .Be("2022-01-01T00:00:00.0000000+00:00");
+    }
+}

--- a/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommandTest.cs
+++ b/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommandTest.cs
@@ -200,7 +200,7 @@ public class CreateCopilotOperationCommandTest
             entity.Details.Should().Be(testJsonContent.Doc?.Details ?? string.Empty);
 
             var entityOperators = (from @operator in testJsonContent.Operators ?? Array.Empty<TestOperatorContent>()
-                select $"{@operator.Name}::{@operator.Skill?.ToString() ?? "1"}").Distinct().ToList();
+                                   select $"{@operator.Name}::{@operator.Skill?.ToString() ?? "1"}").Distinct().ToList();
             entity.Operators.Should().BeEquivalentTo(entityOperators);
         }
     }

--- a/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommandTest.cs
+++ b/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommandTest.cs
@@ -73,12 +73,12 @@ public class CreateCopilotOperationCommandTest
     [TestMethod]
     public async Task TestHandle_Full()
     {
-        var testJsonContent = new TestRequestContent
+        var testJsonContent = new CreateCopilotOperationContent
         {
             StageName = "test_stage_name",
             MinimumRequired = "0.0.1",
-            Doc = new TestDocContent { Title = "test_title", Details = "test_details" },
-            Operators = new TestOperatorContent[]
+            Doc = new Doc { Title = "test_title", Details = "test_details" },
+            Operators = new Operator[]
             {
                 new() { Name = "test_oper_0_name", Skill = 0 }, new() { Name = "test_oper_1_name", Skill = 1 }
             }
@@ -93,11 +93,11 @@ public class CreateCopilotOperationCommandTest
     [TestMethod]
     public async Task TestHandle_WithoutDoc()
     {
-        var testJsonContent = new TestRequestContent
+        var testJsonContent = new CreateCopilotOperationContent
         {
             StageName = "test_stage_name",
             MinimumRequired = "0.0.1",
-            Operators = new TestOperatorContent[]
+            Operators = new Operator[]
             {
                 new() { Name = "test_oper_0_name", Skill = 0 }, new() { Name = "test_oper_1_name", Skill = 1 }
             }
@@ -112,11 +112,11 @@ public class CreateCopilotOperationCommandTest
     [TestMethod]
     public async Task TestHandle_WithoutDocUndefined()
     {
-        var testJsonContent = new TestRequestContent
+        var testJsonContent = new CreateCopilotOperationContent
         {
             StageName = "test_stage_name",
             MinimumRequired = "0.0.1",
-            Operators = new TestOperatorContent[]
+            Operators = new Operator[]
             {
                 new() { Name = "test_oper_0_name", Skill = 0 }, new() { Name = "test_oper_1_name", Skill = 1 }
             }
@@ -131,11 +131,11 @@ public class CreateCopilotOperationCommandTest
     [TestMethod]
     public async Task TestHandle_MissingOperatorName()
     {
-        var testJsonContent = new TestRequestContent
+        var testJsonContent = new CreateCopilotOperationContent
         {
             StageName = "test_stage_name",
             MinimumRequired = "0.0.1",
-            Operators = new TestOperatorContent[]
+            Operators = new Operator[]
             {
                 new() { Skill = 0 }, new() { Name = "test_oper_1_name", Skill = 1 }
             }
@@ -150,11 +150,11 @@ public class CreateCopilotOperationCommandTest
     [TestMethod]
     public async Task TestHandle_DuplicateOperators()
     {
-        var testJsonContent = new TestRequestContent
+        var testJsonContent = new CreateCopilotOperationContent
         {
             StageName = "test_stage_name",
             MinimumRequired = "0.0.1",
-            Operators = new TestOperatorContent[]
+            Operators = new Operator[]
             {
                 new() { Name = "test_oper_0_name", Skill = 0 }, new() { Name = "test_oper_0_name", Skill = 0 }
             }
@@ -162,7 +162,7 @@ public class CreateCopilotOperationCommandTest
         await TestHandle(testJsonContent);
     }
 
-    private async Task TestHandle(TestRequestContent testJsonContent, bool expectException = false,
+    private async Task TestHandle(CreateCopilotOperationContent testJsonContent, bool expectException = false,
         bool removeNullFields = false)
     {
         var testContent = JsonSerializer.Serialize(testJsonContent,
@@ -199,75 +199,9 @@ public class CreateCopilotOperationCommandTest
             entity.Title.Should().Be(testJsonContent.Doc?.Title ?? string.Empty);
             entity.Details.Should().Be(testJsonContent.Doc?.Details ?? string.Empty);
 
-            var entityOperators = (from @operator in testJsonContent.Operators ?? Array.Empty<TestOperatorContent>()
+            var entityOperators = (from @operator in testJsonContent.Operators ?? Array.Empty<Operator>()
                                    select $"{@operator.Name}::{@operator.Skill?.ToString() ?? "1"}").Distinct().ToList();
             entity.Operators.Should().BeEquivalentTo(entityOperators);
         }
     }
-}
-
-/// <summary>
-/// The test JSON request content.
-/// </summary>
-internal record TestRequestContent
-{
-    /// <summary>
-    /// The <c>stage_name</c> field.
-    /// </summary>
-    [JsonPropertyName("stage_name")]
-    public string? StageName { get; set; }
-
-    /// <summary>
-    /// The <c>minimum_required</c> field.
-    /// </summary>
-    [JsonPropertyName("minimum_required")]
-    public string? MinimumRequired { get; set; }
-
-    /// <summary>
-    /// The <c>doc</c> field.
-    /// </summary>
-    [JsonPropertyName("doc")]
-    public TestDocContent? Doc { get; set; }
-
-    /// <summary>
-    /// The <c>opers</c> field.
-    /// </summary>
-    [JsonPropertyName("opers")]
-    public TestOperatorContent[]? Operators { get; set; }
-}
-
-/// <summary>
-/// The test JSON content of <c>doc</c>.
-/// </summary>
-internal record TestDocContent
-{
-    /// <summary>
-    /// The <c>title</c> field.
-    /// </summary>
-    [JsonPropertyName("title")]
-    public string? Title { get; set; }
-
-    /// <summary>
-    /// The <c>details</c> field.
-    /// </summary>
-    [JsonPropertyName("details")]
-    public string? Details { get; set; }
-}
-
-/// <summary>
-/// The test JSON content of <c>operator</c>.
-/// </summary>
-internal record TestOperatorContent
-{
-    /// <summary>
-    /// The <c>name</c> field.
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
-
-    /// <summary>
-    /// The <c>skill</c> field.
-    /// </summary>
-    [JsonPropertyName("skill")]
-    public int? Skill { get; set; }
 }

--- a/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommandValidatorTest.cs
+++ b/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommandValidatorTest.cs
@@ -1,0 +1,75 @@
+// This file is a part of MaaCopilotServer project.
+// MaaCopilotServer belongs to the MAA organization.
+// Licensed under the AGPL-3.0 license.
+
+using System.Text.Json;
+using MaaCopilotServer.Application.CopilotOperation.Commands.CreateCopilotOperation;
+
+namespace MaaCopilotServer.Application.Test.CopilotOperation.Commands.CreateCopilotOperation;
+
+/// <summary>
+/// Tests for <see cref="CreateCopilotOperationCommandValidator"/>.
+/// </summary>
+[TestClass]
+public class CreateCopilotOperationCommandValidatorTest
+{
+    /// <summary>
+    /// Tests when the request is valid.
+    /// </summary>
+    [TestMethod]
+    public void Test_Valid()
+    {
+        var validationErrorMessage = Substitute.For<Resources.ValidationErrorMessage>();
+        var validator = new CreateCopilotOperationCommandValidator(validationErrorMessage);
+        var data = new CreateCopilotOperationContent()
+        {
+            StageName = "test_stage_name",
+            MinimumRequired = "0.0.1",
+        };
+        var result = validator.Validate(new CreateCopilotOperationCommand()
+        {
+            Content = JsonSerializer.Serialize(data)
+        });
+        result.IsValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Tests when <see cref="CreateCopilotOperationCommand.Content"/> is empty.
+    /// </summary>
+    [TestMethod]
+    public void Test_EmptyContent()
+    {
+        var validationErrorMessage = Substitute.For<Resources.ValidationErrorMessage>();
+        var validator = new CreateCopilotOperationCommandValidator(validationErrorMessage);
+        var result = validator.Validate(new CreateCopilotOperationCommand()
+        {
+            Content = null
+        });
+        result.IsValid.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Tests when required fields are missing in <see cref="CreateCopilotOperationCommand.Content"/>.
+    /// </summary>
+    /// <param name="stageName">The stage name.</param>
+    /// <param name="minimumRequired">The minimum required version.</param>
+    [DataTestMethod]
+    [DataRow("test_stage_name", null)]
+    [DataRow(null, "0.0.1")]
+    [DataRow(null, null)]
+    public void Test_MissingRequiredFields(string? stageName, string? minimumRequired)
+    {
+        var validationErrorMessage = Substitute.For<Resources.ValidationErrorMessage>();
+        var validator = new CreateCopilotOperationCommandValidator(validationErrorMessage);
+        var data = new CreateCopilotOperationContent()
+        {
+            StageName = stageName,
+            MinimumRequired = minimumRequired,
+        };
+        var result = validator.Validate(new CreateCopilotOperationCommand()
+        {
+            Content = JsonSerializer.Serialize(data)
+        });
+        result.IsValid.Should().BeFalse();
+    }
+}

--- a/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/DeleteCopilotOperation/DeleteCopilotOperationCommandTest.cs
+++ b/test/MaaCopilotServer.Application.Test/CopilotOperation/Commands/DeleteCopilotOperation/DeleteCopilotOperationCommandTest.cs
@@ -1,0 +1,113 @@
+// This file is a part of MaaCopilotServer project.
+// MaaCopilotServer belongs to the MAA organization.
+// Licensed under the AGPL-3.0 license.
+
+using MaaCopilotServer.Application.Common.Interfaces;
+using MaaCopilotServer.Application.CopilotOperation.Commands.DeleteCopilotOperation;
+using MaaCopilotServer.Application.Test.TestHelpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace MaaCopilotServer.Application.Test.CopilotOperation.Commands.DeleteCopilotOperation;
+
+/// <summary>
+/// Tests for <see cref="DeleteCopilotOperationCommandHandler"/>.
+/// </summary>
+[TestClass]
+public class DeleteCopilotOperationCommandTest
+{
+    /// <summary>
+    ///     The API error message.
+    /// </summary>
+    private Resources.ApiErrorMessage _apiErrorMessage;
+
+    /// <summary>
+    ///     The service for processing copilot ID.
+    /// </summary>
+    private ICopilotIdService _copilotIdService;
+
+    /// <summary>
+    ///     The service for current user.
+    /// </summary>
+    private ICurrentUserService _currentUserService;
+
+    /// <summary>
+    ///     The DB context.
+    /// </summary>
+    private IMaaCopilotDbContext _dbContext;
+
+    /// <summary>
+    /// Initializes tests.
+    /// </summary>
+    [TestInitialize]
+    public void Initialize()
+    {
+        _copilotIdService = Substitute.For<ICopilotIdService>();
+
+        _currentUserService = Substitute.For<ICurrentUserService>();
+        _currentUserService.GetUserIdentity().Returns(Guid.Empty);
+
+        _dbContext = TestDatabaseHelper.GetTestDbContext();
+
+        _apiErrorMessage = new Resources.ApiErrorMessage();
+    }
+
+    /// <summary>
+    /// Tests <see cref="DeleteCopilotOperationCommandHandler.Handle(DeleteCopilotOperationCommand, CancellationToken)"/>.
+    /// </summary>
+    [TestMethod]
+    public void TestHandle()
+    {
+        _dbContext.CopilotOperations.Add(new Domain.Entities.CopilotOperation()
+        {
+            Id = 10000,
+        });
+        _dbContext.SaveChangesAsync(new CancellationToken()).Wait();
+
+        _copilotIdService.DecodeId(Arg.Any<string>()).ReturnsForAnyArgs(10000);
+        var handler = new DeleteCopilotOperationCommandHandler(
+            _dbContext, _copilotIdService, _currentUserService, _apiErrorMessage);
+        var result = handler.Handle(new DeleteCopilotOperationCommand(), new CancellationToken())
+                            .GetAwaiter()
+                            .GetResult();
+
+        result.StatusCode.Should().Be(StatusCodes.Status200OK);
+        _dbContext.CopilotOperations.Any().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Tests <see cref="DeleteCopilotOperationCommandHandler.Handle(DeleteCopilotOperationCommand, CancellationToken)"/>
+    /// with invalid ID.
+    /// </summary>
+    [TestMethod]
+    public void TestHandle_InvalidId()
+    {
+        _copilotIdService.DecodeId(Arg.Any<string>()).ReturnsForAnyArgs((long?)null);
+
+        var handler = new DeleteCopilotOperationCommandHandler(
+            _dbContext, _copilotIdService, _currentUserService, _apiErrorMessage);
+        var result = handler.Handle(new DeleteCopilotOperationCommand(), new CancellationToken())
+                            .GetAwaiter()
+                            .GetResult();
+
+        result.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// Tests <see cref="DeleteCopilotOperationCommandHandler.Handle(DeleteCopilotOperationCommand, CancellationToken)"/>
+    /// with non-existing ID.
+    /// </summary>
+    [TestMethod]
+    public void TestHandle_IdNotFound()
+    {
+        _copilotIdService.DecodeId(Arg.Any<string>()).ReturnsForAnyArgs(10000);
+
+        var handler = new DeleteCopilotOperationCommandHandler(
+            _dbContext, _copilotIdService, _currentUserService, _apiErrorMessage);
+        var result = handler.Handle(new DeleteCopilotOperationCommand(), new CancellationToken())
+                            .GetAwaiter()
+                            .GetResult();
+
+        result.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+}

--- a/test/MaaCopilotServer.Application.Test/MaaCopilotServer.Application.Test.csproj
+++ b/test/MaaCopilotServer.Application.Test/MaaCopilotServer.Application.Test.csproj
@@ -9,16 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10"/>
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10"/>
-    <PackageReference Include="coverlet.collector" Version="3.1.2"/>
-    <PackageReference Include="NSubstitute" Version="4.3.0"/>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MaaCopilotServer.Application\MaaCopilotServer.Application.csproj"/>
+    <ProjectReference Include="..\..\src\MaaCopilotServer.Application\MaaCopilotServer.Application.csproj" />
+    <ProjectReference Include="..\..\src\MaaCopilotServer.Infrastructure\MaaCopilotServer.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/MaaCopilotServer.Application.Test/TestHelpers/TestDatabaseHelper.cs
+++ b/test/MaaCopilotServer.Application.Test/TestHelpers/TestDatabaseHelper.cs
@@ -1,0 +1,30 @@
+// This file is a part of MaaCopilotServer project.
+// MaaCopilotServer belongs to the MAA organization.
+// Licensed under the AGPL-3.0 license.
+
+using MaaCopilotServer.Application.Common.Interfaces;
+using MaaCopilotServer.Infrastructure.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace MaaCopilotServer.Application.Test.TestHelpers;
+
+/// <summary>
+/// The helper class to create in-memory database for testing.
+/// </summary>
+public static class TestDatabaseHelper
+{
+    /// <summary>
+    /// Gets in-memory database context.
+    /// </summary>
+    /// <returns>The database context.</returns>
+    public static IMaaCopilotDbContext GetTestDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MaaCopilotDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+
+        var db = new MaaCopilotDbContext(options);
+        return db;
+    }
+}


### PR DESCRIPTION
#25 

本次改动较大，但大部分都是测试环境的内容。

主要功能为解决了之前一直无法保证 Handler 正确性的问题。重点查看 `test/MaaCopilotServer.Application.Test/TestHelpers/TestDatabaseHelper.cs` 里的函数，以及 `src/MaaCopilotServer.Infrastructure/Database/MaaCopilotDbContext.cs` 的改动。

----

新的 Handler 测试流程：
|修改前|修改后|
|---|---|
|使用`NSubstitute`替换`IMaaDbContext`，十分低效且容易出错，完全没有测试的感觉。|使用内存中的临时数据库。由于是真正的数据库，各种功能都相当完备，而且测试完毕即销毁，不留任何垃圾。|

另外，`NSubstitute` 似乎在各个方面都有些过时，一些有用的功能也不全（比如 `ILogger` 的测试部分需要验证 `Log<任何类型>()` 方法是否被调用，这个“任何类型”无法提供），正在考虑是否要换 `Moq` 库。