### PR TITLE
检索更新

### DIFF
--- a/api-spec.json
+++ b/api-spec.json
@@ -1240,6 +1240,14 @@
             }
           },
           {
+            "name": "document",
+            "in": "query",
+            "description": "The Title and Details to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "operator",
             "in": "query",
             "description": "    The operator query string. Use `,` to split multiple expressions. All expressions will be combined with AND.\r\nThe expression defaults to `Include`, add `~` at the beginning to perform an `Exclude` operation. Eg: `A,~B,C`\r\nwill be translate to `Must include A and C, and must exclude B`. The operator query will not be only applied to\r\nthe `Operators` field of copilot operation. It will not be applied to the `Groups` field, because this field is\r\ntoo complex to perform a query on. Be aware that `Exclude` operation is performed before `Include` operation.",

--- a/src/MaaCopilotServer.Application/Arknights/GetLevelList/GetLevelListDto.cs
+++ b/src/MaaCopilotServer.Application/Arknights/GetLevelList/GetLevelListDto.cs
@@ -39,6 +39,8 @@ public class GetLevelListDto
     public GetLevelListDto() { }
 #pragma warning restore CS8618
 
+    private string _levelId = string.Empty;
+    
     /// <summary>
     ///     Category one of the level.
     /// </summary>
@@ -72,7 +74,10 @@ public class GetLevelListDto
     /// </summary>
     [Required]
     [JsonPropertyName("level_id")]
-    public string LevelId { get; set; }
+    public string LevelId {
+        get => Custom ? _levelId.Replace("copilot-custom/", string.Empty) : _levelId;
+        set => _levelId = value;
+    }
 
     /// <summary>
     ///     The width of the level.

--- a/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommand.cs
+++ b/src/MaaCopilotServer.Application/CopilotOperation/Commands/CreateCopilotOperation/CreateCopilotOperationCommand.cs
@@ -56,9 +56,16 @@ public class CreateCopilotOperationCommandHandler : IRequestHandler<CreateCopilo
         // Get user
         var user = (await _currentUserService.GetUser()).IsNotNull();
 
+        // Check if the stage is custom stage or not
+        var realContent = validationResult.ArkLevel!.Custom
+            ? request.Content!.Replace(
+                validationResult.ArkLevel.LevelId,
+                validationResult.ArkLevel.LevelId.Replace("copilot-custom/", string.Empty))
+            : request.Content!;
+
         // Build entity
         var entity = new Domain.Entities.CopilotOperation(
-            request.Content!,
+            realContent,
             obj.MinimumRequired!,
             obj.Doc!.Title!,
             obj.Doc!.Details!,


### PR DESCRIPTION
fix #96

关卡 ID
- 新增自定义关卡时，使用标准 ID
- 在上传自定义关卡的作业前，前端需要检查关卡的 `custom` 属性，若为 true，则为 `stage_name` 添加 `copilot-custom/` 前缀
- 任何检索 API 均会返回不带有前缀的 ID

检索
- 新增 `document` 项用于检索 Title 与 Details
