### PR TITLE
fix: 查询参数中的 operator 不完全生效

### DIFF
--- a/src/MaaCopilotServer.Application/CopilotOperation/Queries/QueryCopilotOperations/QueryCopilotOperationsQuery.cs
+++ b/src/MaaCopilotServer.Application/CopilotOperation/Queries/QueryCopilotOperations/QueryCopilotOperationsQuery.cs
@@ -235,11 +235,11 @@ public class QueryCopilotOperationsQueryHandler : IRequestHandler<QueryCopilotOp
             
             var conditions = request.Operator.Split(",");
             var exclude = conditions
-                .Where(x => x.Length > 2)
+                .Where(x => x.Length > 1)
                 .Where(x => x.StartsWith("~"))
                 .Select(x => x[1..]);
             var include = conditions
-                .Where(x => x.Length > 1)
+                .Where(x => x.Length > 0)
                 .Where(x => x.StartsWith("~") is false);
 
             // The following aggregated complex query can not be translated to SQL.

--- a/src/MaaCopilotServer.Application/CopilotOperation/Queries/QueryCopilotOperations/QueryCopilotOperationsQuery.cs
+++ b/src/MaaCopilotServer.Application/CopilotOperation/Queries/QueryCopilotOperations/QueryCopilotOperationsQuery.cs
@@ -252,9 +252,8 @@ public class QueryCopilotOperationsQueryHandler : IRequestHandler<QueryCopilotOp
 
             e = exclude.Aggregate(e,
                 (current, condition) => 
-                    current
-                        .SkipWhile(x =>
-                            x.Operators.Any(y => y.Contains(condition))));
+                    current.Where(x =>
+                        x.Operators.Any(y => y.Contains(condition) is false)));
             e = include.Aggregate(e,
                 (current, condition) =>
                     current.Where(x =>


### PR DESCRIPTION
- 使用 exclude operator 时只会排除一部分作业，因为 `SkipWhile` 只会排除最前面一批不符合条件的元素

![COKGB 16S%%DF3471ZH3K7X](https://user-images.githubusercontent.com/46285865/192929357-7fd29b54-e72d-46b2-9e20-38a57d94e946.png)

- operator 中的单字干员不生效，比如煌

![image](https://user-images.githubusercontent.com/46285865/192929662-b54c4005-e90e-4716-a6b1-8fa0ac125176.png)

