### PR TITLE
feat: support negative cost_changes

### DIFF
--- a/src/MaaCopilotServer.Resources/maa-copilot-schema.json
+++ b/src/MaaCopilotServer.Resources/maa-copilot-schema.json
@@ -210,8 +210,7 @@
         },
         "cost_changes": {
           "type": "integer",
-          "description": "Waiting until the cost changes for the amount specified, optional, 0 by default.",
-          "minimum": 0
+          "description": "Waiting until the cost changes for the amount specified, optional, 0 by default."
         },
         "cooling": {
           "type": "integer",


### PR DESCRIPTION
```
            "cost_changes": 5,      // 费用变化量条件，如果没达到就一直等待。可选，默认为 0，直接执行
                                    // 注意是从开始执行本 actions 开始计算的（即前一个 action 结束时的费用作为基准）
                                    // 支持负数，即费用变少了（例如“孑”等吸费干员使得费用变少了）
                                    // 另外仅在费用是两位数的时候识别的比较准，三位数的费用可能会识别错，不推荐使用
```